### PR TITLE
[RFC] Hash.concat works with non-hash arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,9 @@ Makefile
 Makefile.old
 MANIFEST.bak
 META.yml
+META.json
 MYMETA.yml
+MYMETA.json
 nytprof.out
 pm_to_blib
 .project

--- a/MANIFEST
+++ b/MANIFEST
@@ -735,6 +735,7 @@ scripts/Tests/hailstone.sf
 scripts/Tests/happy_2_years_old.sf
 scripts/Tests/hash_as_tree.sf
 scripts/Tests/hash_autovivification.sf
+scripts/Tests/hash_concat.sf
 scripts/Tests/hash_from_array.sf
 scripts/Tests/hash_grep.sf
 scripts/Tests/hash_sort.sf

--- a/lib/Sidef/Types/Hash/Hash.pm
+++ b/lib/Sidef/Types/Hash/Hash.pm
@@ -306,7 +306,12 @@ package Sidef::Types::Hash::Hash {
 
     sub concat {
         my ($self, $obj) = @_;
-        bless {%$self, %$obj}, ref($self);
+        
+#<<<
+            UNIVERSAL::isa($obj, __PACKAGE__)                  ? bless({%$self, %$obj}, ref($self))
+          : UNIVERSAL::isa($obj, 'Sidef::Types::Array::Array') ? bless({%$self, @$obj}, ref($self))
+          :                                                      bless({%$self,  $obj}, ref($self));
+#>>>
     }
 
     *merge = \&concat;

--- a/scripts/Tests/hash_concat.sf
+++ b/scripts/Tests/hash_concat.sf
@@ -1,0 +1,20 @@
+#!/usr/bin/ruby
+
+#
+## Hash.concat on various things, including non-hashes
+#
+
+var hash = Hash()
+hash += 1
+assert_eq(hash{"1"}, nil)
+
+hash += Hash(:a => :b)
+assert_eq(hash{:a}, :b)
+
+hash += %w(c d)           # 2-item array
+assert_eq(hash{:c}, :d)
+
+hash += "2":3             # an actual Pair
+assert_eq(hash{"2"}, 3)
+
+say "** Test passed!"


### PR DESCRIPTION
The previous behaviour was just a vague error from Perl (`not a HASH reference`).
```
    Hash() + :a            -> Hash("a" => nil)
    Hash() + Pair(1, 2)    -> Hash("1" => 2)
    Hash() + [1, 2]        -> Hash("1" => 2)
```

Also updating .gitignore as committing these generated files seems to be in error

RFC because

1. the tests don't pass (see item 4)
1. Hash() + iterable seems like it might not be right for Sidef-style (it's not a similar pattern elsewhere)

2. I'm used to pairs being just a subset of the array type, so I naturally think that 2-item arrays should work like a Pair in a context where the items will be removed from the actual container anyway (Sidef does not agree as Array and Pair are separate) 

3. Since I don't actually know much Perl it will take me some time to implement `Hash.concat(iterable)` (or a good error for it, if it's a bad idea) 
