### PR TITLE
Regex: new method; Match: pos-related bugs fixed

### DIFF
--- a/lib/Sidef/Types/Regex/Match.pm
+++ b/lib/Sidef/Types/Regex/Match.pm
@@ -43,13 +43,12 @@ package Sidef::Types::Regex::Match {
             }
         }
         else {
-            @captures =
-              defined($hash{pos})
-              ? (substr($hash{string}, $hash{pos}) =~ $hash{regex}{regex})
-              : ($hash{string} =~ $hash{regex}{regex});
+            $hash{pos} = CORE::int($hash{pos} // 0);
+            $hash{pos} = ($hash{pos} >= length($hash{'string'}) || $hash{pos} < 0) ? 0 : $hash{pos};
+            @captures = substr($hash{string}, $hash{pos}) =~ $hash{regex}{regex};
 
             $hash{matched}   = (@captures != 0);
-            $hash{match_pos} = $hash{matched} ? [$-[0] + ($hash{pos} // 0), $+[0] + ($hash{pos} // 0)] : [];
+            $hash{match_pos} = $hash{matched} ? [$-[0] + $hash{pos}, $+[0] + $hash{pos}] : [];
 
             foreach my $key (keys %+) {
                 $hash{named_captures}{$key} = $+{$key};

--- a/scripts/Tests/regex_global_matching.sf
+++ b/scripts/Tests/regex_global_matching.sf
@@ -4,17 +4,31 @@
 ## Regular expressions -- global matching
 #
 
-3.times { |i|
-    say i;
-    while (var m = ("abcd" =~ /(..)/g)) {
-        say m.cap[0];
+3.times {
+    define r = /\G(..)/g
+    var cs = []
+    while (var m = ('abcd' =~ r)[0]) {
+       cs.append(m)
     }
-};
+    assert_eq(cs, ['ab', 'cd'])
+}
 
 
-3.times { |i|
-    say i;
-    while (var m = "abcd".gmatch(/(..)/)) {
-        say m.cap[0];
+3.times {
+    define r = /\G(..)/
+    var cs = []
+    while (var m = 'abcd'.gmatch(r)[0]) {
+        cs.append(m)
     }
-};
+    assert_eq(cs, ['ab', 'cd'])
+}
+
+do {
+ define r = /\G(.)/
+ define s = "1234567"
+ assert_eq(s, r.global_matches(s).map{ _[0] }.join)
+ assert_eq(s, r.global_matches(s, { |_, c| c[0] } ).join)
+ assert_eq([s[3..s.len-1]], r.global_matches(s, 3).map{ _[0] })
+ assert_eq([s[3..s.len-1]], r.global_matches(s, 3, { |_, c| c[0] } ))
+ assert_eq([s[3..s.len-1]], r.global_matches(s,    { |_, c| c[0] }, 3 ))
+}

--- a/scripts/Tests/regex_pos.sf
+++ b/scripts/Tests/regex_pos.sf
@@ -1,0 +1,11 @@
+#!/usr/bin/ruby
+
+define r = /(....)/
+define s = '1234567'
+
+assert_eq('4567', r.match(s, 3)[0] )
+assert_eq('1234', r.match(s, 0)[0] )
+assert_eq('1234', r.match(s, -1)[0] )
+assert_eq('1234', r.match(s, 0.7)[0] )
+assert_eq('1234', r.match(s, 11)[0] )
+assert_eq('1234', r.match(s, 7)[0] )


### PR DESCRIPTION
- `Match`: fix bugs when processing regex/str position

  - Fix a bug where non-global matches' otherwise valid
        `pos` argument would be unused or ignored

  - Out-of-range / invalid values for the `pos` argument
        become 0.

- `Regex`: new method: `global_matches`, and a new alias

  - `Regex.gmatch`'s default declaration is now named
        `global_match`, in the spirit of aliases being
        shorthand, but the alias `gmatch` is still available.

  - A new method `Regex.global_matches` is introduced.

    `global_matches` applies the current Regex to the
        object until it no longer matches, accumulating
        the matches in an Array.

    Most use cases of `gmatch` require a cumbersome loop
        and array append to find all matches anyway;
        `global_matches` makes it easier to quickly and
        cleanly iterate all matches.

    `global_matches` accepts 2 other arguments, which
        may come in any order: `pos` and `block`.

    If `global_matches`' second or third method parameter
        is a Number, it will be used as the initial string
        matching position for the new Match object.

    If the second or third parameter is a Block,
        it will be applied to each match index and the
        match itself in turn, treating indices as keys
        and matches as values.

    This is similar to `map` or `map_kv`, but obviates
        the need to iterate the matches twice -- once
        when matching, and again to `map`.
        This is a significant optimisation with large
        numbers of repeated matches.

    `global_matches` has four aliases: `gmatches`,
        `all_matches`, `repeated_match`, and `map_matches`.

Side notes:
- the not-global branch of Match.new is subsequently cleaned up a little bit 
- because Match.new does some validation now, it's not needed to cast `$pos` when calling `Match->new` in `Regex.match` (and anywhere else Match.new is called, I should have looked)
- the tests for `gmatch` were cleaned up, and made to work properly.
- because `Regex->{pos}` is processed properly now, when using `gmatch`/`gmatches` it's preferred / necessary? to set `local $self->{pos}` rather than the `$pos` argument, because as far as I can tell `$hash{pos}` isn't used anywhere in the global branch of `Match.new`.
