### PR TITLE
Parser: add __DEPARSING_FILE__

### DIFF
--- a/lib/Sidef/Parser.pm
+++ b/lib/Sidef/Parser.pm
@@ -2413,6 +2413,10 @@ package Sidef::Parser {
                 return Sidef::Types::Number::Number->new($self->{line});
             }
 
+            if (/\G__DEPARSING_FILE__\b/gc) {
+                return Sidef::Types::Bool::Bool->new($self->{opt}{R} eq 'Perl');
+            }
+
             if (/\G__(?:END|DATA)__\b\h*+\R?/gc) {
                 if (exists $self->{'__DATA__'}) {
                     $self->{'__DATA__'} = substr($_, pos);


### PR DESCRIPTION
This builtin variable is `true` when the code is
    being deparsed inside -Rperl, and false othe-
    rwise.

Now a Sidef script can detect whether it's being
    deparsed into Perl that isn't going to be
    immediately `eval`'d inside the Sidef interp-
    reter.

This is particularly useful for detecting whether
    <typename>.methods is available, as .methods
    returns an empty Hash on typenames only when
    *not* inside a Perl `eval` insde a Sidef
    interpreter.

Thus,
```ruby
    if (! __DEPARSING_FILE__) {
        say Object.methods # => non-empty Hash
    } else {
        # otherwise use a different strategy
    }
```