### PR TITLE
Fix a warning in const_tests

### DIFF
--- a/scripts/Tests/const_tests.sf
+++ b/scripts/Tests/const_tests.sf
@@ -52,7 +52,7 @@ do {
     assert_eq(v, 42)
 
     func foo(n) {
-        const v = n
+        const _v = n
     }
 
     assert_eq(foo(3), 3)


### PR DESCRIPTION
Using that variable means the test passed with `-W` warnings enabled, just for correctness.