### PR TITLE
Regex: add the 'add' / 'concat' / '+' method

### DIFF
--- a/lib/Sidef/Types/Regex/Regex.pm
+++ b/lib/Sidef/Types/Regex/Regex.pm
@@ -155,6 +155,26 @@ package Sidef::Types::Regex::Regex {
     *map_matches    = \&global_matches;
     *repeated_match = \&global_matches;
 
+    sub add {
+      my ($self, $other, $extra_flags) = @_;
+      my $a = $self->{raw};
+      my ($b, $b_flags, $b_global) = (undef, '', 0);
+      if (CORE::ref($other) eq 'Sidef::Types::Regex::Regex') {
+        $b = $other->{raw};
+        $b_flags = $other->{flags};
+        $b_global = $other->{global};
+      } else {
+        $b = "$other";
+      }
+
+      Sidef::Types::Regex::Regex->new(
+        "$a$b",
+        $self->{flags} . $b_flags . $extra_flags
+          . (($self->{global} || $b_global) ? 'g' : '')
+      )
+    }
+    *concat = \&add;
+
     sub dump {
         my ($self) = @_;
 
@@ -180,6 +200,7 @@ package Sidef::Types::Regex::Regex {
         *{__PACKAGE__ . '::' . '>'}   = \&gt;
         *{__PACKAGE__ . '::' . '≥'}   = \&ge;
         *{__PACKAGE__ . '::' . '>='}  = \&ge;
+        *{__PACKAGE__ . '::' . '+'}  = \&concat;
     }
 
 };

--- a/scripts/Tests/regex_concat.sf
+++ b/scripts/Tests/regex_concat.sf
@@ -1,0 +1,6 @@
+#! ruby
+
+assert_eq(/a/g + /b/i, /ab/gi)
+assert_eq(/(a)/ + /(b)/, /(a)(b)/)
+assert_eq(/a/i + :b, /ab/i)
+assert_eq(/a/i + 1, /a1/i)


### PR DESCRIPTION
Now Regexes can be concatenated with other
    regexes, strings, and stringifiable
    objects to create a new regex which
    matches the concatenation of the
    languages matched by each regex alone.

Flags are preserved and the global flag is
    kept if it is on either operand, and
    new flags can be added using the third
    argument.