### PR TITLE
Regex.global_matches: fix a bug with empty/null regexes never returning

### DIFF
--- a/lib/Sidef/Types/Regex/Regex.pm
+++ b/lib/Sidef/Types/Regex/Regex.pm
@@ -135,14 +135,20 @@ package Sidef::Types::Regex::Regex {
         local $self->{pos}    = CORE::int($pos);
 
         if (defined($block)) {
+            my ($cpos, $lpos) = ($self->{pos}, $self->{pos});
             my $i = 0;
 
             while ((my $m = $self->match($obj))->{matched}) {
+                $lpos = $cpos;
+                last if ($lpos == ($cpos = $self->{pos}));
                 CORE::push(@matches, $block->run(Sidef::Types::Number::Number->_set_uint($i++), $m));
             }
         }
         else {
+            my ($cpos, $lpos) = ($self->{pos}, $self->{pos});
             while ((my $m = $self->match($obj))->{matched}) {
+                $lpos = $cpos;
+                last if ($lpos == ($cpos = $self->{pos}));
                 CORE::push(@matches, $m);
             }
         }

--- a/scripts/Tests/regex_global_matching.sf
+++ b/scripts/Tests/regex_global_matching.sf
@@ -24,17 +24,28 @@
 }
 
 do {
- define r = /\G(.)/
- define s = "1234567"
- assert_eq(s, r.global_matches(s).map{ _[0] }.join)
- assert_eq(s, r.global_matches(s, { |_, c| c[0] } ).join)
- assert_eq([s[3..s.len-1]], r.global_matches(s, 3).map{ _[0] })
- assert_eq([s[3..s.len-1]], r.global_matches(s, 3, { |_, c| c[0] } ))
- assert_eq([s[3..s.len-1]], r.global_matches(s,    { |_, c| c[0] }, 3 ))
- assert_eq([s[2..s.len-1]], r.global_matches(s, 1, 2 ).map{ _[0] })
+    define r = /\G(.)/
+    define s = "1234567"
+    assert_eq(s, r.global_matches(s).map{ _[0] }.join)
+    assert_eq(s, r.global_matches(s, { |_, c| c[0] } ).join)
+    assert_eq([s[3..s.len-1]], r.global_matches(s, 3).map{ _[0] })
+    assert_eq([s[3..s.len-1]], r.global_matches(s, 3, { |_, c| c[0] } ))
+    assert_eq([s[3..s.len-1]], r.global_matches(s,    { |_, c| c[0] }, 3 ))
+    assert_eq([s[2..s.len-1]], r.global_matches(s, 1, 2 ).map{ _[0] })
 
- assert_eq("", r.global_matches(s,    { |_, c| c[0] }, 7.4 ).join)
- assert_eq(s[-1], r.global_matches(s,    { |_, c| c[0] }, -1 ).join)
+    assert_eq("", r.global_matches(s,    { |_, c| c[0] }, 7.4 ).join)
+    assert_eq(s[-1], r.global_matches(s,    { |_, c| c[0] }, -1 ).join)
+
+    # null regexes (empty or empty capture)
+    assert_eq(//.gmatches, [])
+    assert_eq(//.gmatches(:asdf), [])
+    assert_eq(//.gmatches(:asdf, 1, { }), [])
+    assert_eq(/()/.gmatches(), [])
+    assert_eq(/()/.gmatches(:asdf), [])
+    assert_eq(/()/.gmatches(:asdf, { }, 1), [])
+    assert_eq(/(?<a>)/.gmatches(), [])
+    assert_eq(/(?<a>)/.gmatches(:asdf), [])
+    assert_eq(/(?<a>)/.gmatches(:asdf, { }, 1), [])
 }
 
 2.times {


### PR DESCRIPTION
These tests previously looped forever: 

```ruby 
    assert_eq(//.gmatches, [])
    assert_eq(//.gmatches(:asdf), [])
    assert_eq(/()/.gmatches(), [])
    assert_eq(/()/.gmatches(:asdf), [])
    assert_eq(/(?<a>)/.gmatches(), [])
    assert_eq(/(?<a>)/.gmatches(:asdf), [])
```

Because the "null" (empty or null-capture) regex always matches any input, `$match{matched}` is always 1, but the iteration in `Match->new` is not stopped when the end of the input is reached.

`$hash{regex}{pos}` is either reset to `0` and counts up again, or stays at `length($hash{string})` forever. Perhaps `gmatches` needs to keep track of iterating the string only once, so that's the naive fix I've written. 

It might not be the best solution though.