### PR TITLE
Features and improvements to iterable objects

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -634,6 +634,7 @@ scripts/Tests/arithmetic_evaluation.sf
 scripts/Tests/arithmetic_geometric_mean.sf
 scripts/Tests/array_and_hash_lookup.sf
 scripts/Tests/array_and_hash_lvalues.sf
+scripts/Tests/array_any_all.sf
 scripts/Tests/array_autovivification.sf
 scripts/Tests/array_binary_search.sf
 scripts/Tests/array_binsert.sf
@@ -659,6 +660,7 @@ scripts/Tests/binary_search.sf
 scripts/Tests/binary_search_recursive.sf
 scripts/Tests/bitonic_sorter.sf
 scripts/Tests/block_return.sf
+scripts/Tests/block_identities.sf
 scripts/Tests/box_the_compass.sf
 scripts/Tests/break.sf
 scripts/Tests/built_in_class_reopening.sf
@@ -745,6 +747,7 @@ scripts/Tests/happy_2_years_old.sf
 scripts/Tests/hash_as_tree.sf
 scripts/Tests/hash_autovivification.sf
 scripts/Tests/hash_concat.sf
+scripts/Tests/hash_selection.sf
 scripts/Tests/hash_from_array.sf
 scripts/Tests/hash_grep.sf
 scripts/Tests/hash_sort.sf
@@ -912,6 +915,7 @@ scripts/Tests/script.sf
 scripts/Tests/selection_sort.sf
 scripts/Tests/set_consolidation.sf
 scripts/Tests/set_operations.sf
+scripts/Tests/set_any_all.sf
 scripts/Tests/sets_1.sf
 scripts/Tests/sets_2.sf
 scripts/Tests/sidef_executor.sf

--- a/lib/Sidef/Types/Array/Array.pm
+++ b/lib/Sidef/Types/Array/Array.pm
@@ -15,6 +15,7 @@ package Sidef::Types::Array::Array {
       q{bool} => sub { scalar(@{$_[0]}) };
 
     use Sidef::Types::Number::Number;
+    use Sidef::Types::Block::Block;
 
     sub new {
         (@_ == 2 && ref($_[1]) eq 'ARRAY')
@@ -1364,9 +1365,7 @@ package Sidef::Types::Array::Array {
     sub expand {
         my ($self, $block) = @_;
 
-        if (not defined($block)) {
-            $block = Sidef::Types::Block::Block->new(code => sub { $_[0] });
-        }
+        $block //= Sidef::Types::Block::Block::IDENTITY;
 
         my @new;
         my @copy = @$self;
@@ -1390,9 +1389,7 @@ package Sidef::Types::Array::Array {
     sub recmap {
         my ($self, $block) = @_;
 
-        if (not defined($block)) {
-            $block = Sidef::Types::Block::Block->new(code => sub { $_[0] });
-        }
+        $block = Sidef::Types::Block::Block::IDENTITY;
 
         my @copy = @$self;
 
@@ -1636,6 +1633,8 @@ package Sidef::Types::Array::Array {
     sub any {
         my ($self, $block) = @_;
 
+        $block //= Sidef::Types::Block::Block::IDENTITY;
+
         foreach my $val (@$self) {
             $block->run($val)
               && return (Sidef::Types::Bool::Bool::TRUE);
@@ -1647,6 +1646,8 @@ package Sidef::Types::Array::Array {
     sub all {
         my ($self, $block) = @_;
 
+        $block //= Sidef::Types::Block::Block::IDENTITY;
+
         foreach my $val (@$self) {
             $block->run($val)
               || return (Sidef::Types::Bool::Bool::FALSE);
@@ -1657,6 +1658,8 @@ package Sidef::Types::Array::Array {
 
     sub none {
         my ($self, $block) = @_;
+
+        $block //= Sidef::Types::Block::Block::IDENTITY;
 
         foreach my $val (@$self) {
             $block->run($val)

--- a/lib/Sidef/Types/Block/Block.pm
+++ b/lib/Sidef/Types/Block/Block.pm
@@ -26,6 +26,11 @@ package Sidef::Types::Block::Block {
           . " #`($name|$addr) ... }";
       };
 
+    use constant {
+                  IDENTITY => (bless { code => sub { $_[0] }, name => '__BLOCK__', type => 'block' }, __PACKAGE__ ),
+                  LIST_IDENTITY => (bless { code => sub { (@_) }, name => '__BLOCK__', type => 'block' }, __PACKAGE__ ),
+                 };
+
     sub new {
         my (undef, %opt) = @_;
 
@@ -36,6 +41,9 @@ package Sidef::Types::Block::Block {
               },
           __PACKAGE__;
     }
+
+    sub identity      { bless IDENTITY, __PACKAGE__; }
+    sub list_identity { bless LIST_IDENTITY, __PACKAGE__; }
 
     sub run {
 

--- a/lib/Sidef/Types/Set/Set.pm
+++ b/lib/Sidef/Types/Set/Set.pm
@@ -12,6 +12,7 @@ package Sidef::Types::Set::Set {
       q{0+}   => sub { scalar(CORE::keys(%{$_[0]})) },
       q{""}   => \&_dump;
 
+    use Sidef::Types::Block::Block;
     use Sidef::Types::Bool::Bool;
     use Sidef::Types::Number::Number;
 
@@ -103,6 +104,9 @@ package Sidef::Types::Set::Set {
     sub difference {
         my ($A, $B) = @_;
 
+        if (ref($B) eq 'Sidef::Types::Hash::Hash') {
+            $B = $B->keys;
+        }
         if (ref($B) ne __PACKAGE__) {
             $B = $B->to_set;
         }
@@ -387,6 +391,45 @@ package Sidef::Types::Set::Set {
     sub join {
         my ($self, @rest) = @_;
         $self->to_a->join(@rest);
+    }
+
+    sub all {
+        my ($self, $block) = @_;
+
+        $block //= Sidef::Types::Block::Block::IDENTITY;
+
+        my $d = $self->dclone;
+        while ( defined(my $v = $d->pop) ) {
+            $block->run($v) or return Sidef::Types::Bool::Bool::FALSE
+        }
+
+        Sidef::Types::Bool::Bool::TRUE
+    }
+
+    sub any {
+        my ($self, $block) = @_;
+
+        $block //= Sidef::Types::Block::Block::IDENTITY;
+
+        my $d = $self->dclone;
+        while ( defined(my $v = $d->pop) ) {
+            $block->run($v) and return Sidef::Types::Bool::Bool::TRUE
+        }
+
+        Sidef::Types::Bool::Bool::FALSE
+    }
+
+    sub none {
+        my ($self, $block) = @_;
+
+        $block //= Sidef::Types::Block::Block::IDENTITY;
+
+        my $d = $self->dclone;
+        while ( defined(my $v = $d->pop) ) {
+            $block->run($v) and return Sidef::Types::Bool::Bool::FALSE
+        }
+
+        Sidef::Types::Bool::Bool::TRUE
     }
 
     sub _dump {

--- a/scripts/Tests/array_any_all.sf
+++ b/scripts/Tests/array_any_all.sf
@@ -1,0 +1,18 @@
+#! /usr/bin/ruby
+
+assert_eq( true, [true, true].all{ _ } )
+assert_eq( true, [true, true].all )
+assert_eq( false, [false, true].all{ _ } )
+assert_eq( false, [false, true].all )
+
+assert_eq( true, [4, 2, 0].none{ .is_odd } )
+assert_eq( true, [false, false].none{ _ } )
+assert_eq( true, [false, false].none )
+assert_eq( false, [false, true].none )
+
+assert_eq( true, [false, true].any{ _ })
+assert_eq( true, [false, true].any)
+assert_eq( true, [1, 2, 0, 3].any{ .is_zero } )
+assert_eq( false, [true, true].any{ !_ } )
+
+say "** Test passed!"

--- a/scripts/Tests/block_identities.sf
+++ b/scripts/Tests/block_identities.sf
@@ -1,0 +1,9 @@
+#! /usr/bin/ruby
+
+20.times{
+    assert_eq( 0..100 -> map(Block.identity), 0..100 -> to_a )
+
+    assert_eq( Hash(1, 2, 3, 4, 5, 6) -> map_kv(Block.list_identity), Hash(1, 2, 3, 4, 5, 6) )
+}
+
+say "** Test passed!"

--- a/scripts/Tests/hash_selection.sf
+++ b/scripts/Tests/hash_selection.sf
@@ -1,0 +1,86 @@
+#! /usr/bin/ruby
+
+const hash = Hash(1 => nil, :a => :b, :c => :d, :2 => 3)
+
+say 'Hash:'
+say 'Linear Selection'
+say "\tof a Hash"
+100.times {
+    assert_eq( hash.linsel(hash.keys), hash )
+    assert_eq( hash.linsel([]), Hash() )
+    assert_eq( hash.linsel([:nothing, :no_one]), Hash(:nothing => nil, :no_one => nil) )
+    assert_eq( hash.linsel([1, :a]), Hash(1 => nil, :a => :b) )
+
+    assert_eq( hash.linsel(hash.keys.to_set), hash )
+    assert_eq( hash.linsel(Set()), Hash() )
+    assert_eq( hash.linsel(Set(:nothing, :no_one)), Hash(:nothing => nil, :no_one => nil) )
+    assert_eq( hash.linsel(Set(2, :c)), Hash(:2 => 3, :c => :d) )
+}
+say 'Intersection'
+say "\twith a Set"
+100.times {
+    assert_eq( hash & Set(:a, :2), Hash(:a => :b, :2 => 3) )
+    assert_eq( hash & Set(:not_key, :c), Hash(:c => :d) )
+    assert_eq( hash & Set(), Hash() )
+}
+say "\twith a Hash"
+100.times {
+    assert_eq( hash & hash, hash )
+    assert_eq( hash & Hash(:nothing => nil, :a => :unused), Hash(:a => :b) )
+    assert_eq( hash & Hash(), Hash() )
+}
+say 'Difference'
+say "\twith a Set"
+100.times{
+    assert_eq( hash - Set(), hash )
+    assert_eq( hash - Set(:1, :a), Hash(:c => :d, :2 => 3) )
+    assert_eq( hash - Set(:1, :2, :nothing), Hash(:a => :b, :c => :d) )
+    assert_eq( hash - Set(:1, :a, :c, :2), Hash())
+    assert_eq( hash - hash.keys.to_set, Hash())
+}
+say "\twith a Hash"
+100.times{
+    assert_eq(hash - Hash(), hash)
+    assert_eq(hash - Hash(:1 => :unused, :2 => nil), Hash(:a => :b, :c => :d))
+    assert_eq(hash - Hash(:nothing => :unused, :c => nil), Hash(:a => :b, :2 => 3, :1 => nil))
+    assert_eq(hash - hash, Hash())
+}
+say 'Union'
+say "\twith a Set"
+100.times{
+    assert_eq( hash | Set(), hash )
+    assert_eq( hash | Set(:new), hash + Hash(:new) )
+    assert_eq( hash | Set(:new2, :new3), hash + Hash(:new2 => nil, :new3 => nil) )
+}
+say "\twith a Hash"
+100.times{
+    assert_eq( hash | Hash(), hash )
+    assert_eq( hash | Hash(:new), hash + Hash(:new) )
+    assert_eq( hash | hash, hash )
+}
+say 'Symdiff'
+say "\twith a Set"
+100.times{
+    assert_eq( hash ^ Set(), hash )
+    assert_eq( hash ^ Set(:1, :2), Hash(:a => :b, :c => :d) )
+    assert_eq( hash ^ hash.keys.to_set, Hash() )
+}
+say "\twith a Hash"
+100.times{
+    assert_eq( hash ^ hash, Hash() )
+    assert_eq( hash ^ Hash(:new => nil, :new1 => nil), hash + Hash( :new => nil, :new1 => nil ) )
+    assert_eq( hash ^ Hash(), hash )
+}
+say 'Difference of a Set and Hash'
+100.times{
+    assert_eq( Set() - hash, Set() )
+    assert_eq( Set(:1) - hash, Set() )
+    assert_eq( Set(:extra) - hash, Set(:extra) )
+    assert_eq( hash.keys.to_set - hash, Set() )
+
+    assert_eq( @(0..10).to_set.map{ .to_s } - Hash(), @(0..10).to_set.map{ .to_s } )
+
+    assert_eq( @(0..10).to_set.map{ .to_s } - Hash(0=>nil, 1=>nil, 2=>nil, 3=>nil), @(4..10).to_set.map{ .to_s } )
+}
+
+say "\n** Test passed!"

--- a/scripts/Tests/set_any_all.sf
+++ b/scripts/Tests/set_any_all.sf
@@ -1,0 +1,23 @@
+#! /usr/bin/ruby
+
+const evens = Set(0, 2, 4)
+const evennat = Set(2, 4, 6)
+const falses = Set(0, '', [], Hash(), false)
+
+assert_eq( true, evens.all{ .is_even } )
+assert_eq( true, evennat.all )
+assert_eq( false, evens.all{ _ } )
+assert_eq( false, evens.all )
+
+assert_eq( true, evens.none{ .is_odd } )
+assert_eq( true, evennat.none{ !_ } )
+assert_eq( true, falses.none )
+assert_eq( false, falses + Set(true) -> none )
+
+assert_eq( true, falses + Set(true) -> any{ _ })
+assert_eq( true, falses + Set(true) -> any)
+assert_eq( true, evens.any{ .is_zero } )
+assert_eq( false, falses.any{ _ } )
+assert_eq( false, falses.any )
+
+say "** Test passed!"


### PR DESCRIPTION
- add the any, all and none Set methods, which
    necessitate a dclone that can sometimes be
    preferred over conversion to an Array

- .any, .all, and .none on Set and Array can be
    called without a block, like map

- Block: new constants, IDENTITY and LIST_IDENTITY
    which return their argument or arguments,
    respectively, to lessen runtime overhead for
    these tiny but common callables.

User code can construct these with Block.identity
    and Block.list_identity.

- Array: use the IDENTITY block if a method that
    wants a block, wasn't called with one.
    This eliminates some runtime overhead for
    nested loops, and cleans up the code with
    fewer immediate anonymous subs that can
    introduce typos.

- add the Hash.linear_selection method, which
    creates a Hash that is a subset of a hash,
    given an iterable argument of keys

- linear_selection, useful on its own, is used
    to implement Set-like operations on Hashes,
    with Sets, Hashes, Arrays, and other iterables
    on the RHS.

- Now it's possible to intersect, difference,
    union and symdiff Hashes with other objects.
    These operate primarily on the Hashes' keys.

- Last, Set.difference is extended to allow a
    Hash on the RHS, for subtracting a Hash's
    keys from a Set without needing to iterate
    it twice.