### PR TITLE
New 'rest' methods for Set and Array, and aliases

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -915,6 +915,7 @@ scripts/Tests/script.sf
 scripts/Tests/selection_sort.sf
 scripts/Tests/set_any_all.sf
 scripts/Tests/set_consolidation.sf
+scripts/Tests/set_first_rest.sf
 scripts/Tests/set_operations.sf
 scripts/Tests/sets_1.sf
 scripts/Tests/sets_2.sf

--- a/lib/Sidef/Types/Array/Array.pm
+++ b/lib/Sidef/Types/Array/Array.pm
@@ -1624,6 +1624,7 @@ package Sidef::Types::Array::Array {
         @$self ? $self->[0] : undef;
     }
 
+    *car  = \&first;
     *head = \&first;
 
     sub last_by {
@@ -1661,6 +1662,19 @@ package Sidef::Types::Array::Array {
     }
 
     *tail = \&last;
+
+    sub rest {
+        my ($self, $offset) = (@_);
+
+        $offset = CORE::int($offset);
+        $offset = $offset <= 0 ? 1 : $offset;
+
+        my $ilen = CORE::int($self->len);
+
+        $self->last( $ilen - ($offset > $ilen ? 1 : $offset) )
+    }
+
+    *cdr = \&rest;
 
     sub any {
         my ($self, $block) = @_;

--- a/lib/Sidef/Types/Set/Set.pm
+++ b/lib/Sidef/Types/Set/Set.pm
@@ -258,6 +258,19 @@ package Sidef::Types::Set::Set {
         $self;
     }
 
+    sub first_rest {
+        my ($self) = @_;
+
+        my @keys = CORE::keys(%$self);
+        my ($rest, $key) = ($self->dclone, $keys[0]);
+        CORE::delete($rest->{$key});
+
+        ($self->{$key}, $rest);
+    }
+
+    *car_cdr = \&first_rest;
+    *split1  = \&car_cdr;
+
     sub sort_by {
         my ($self, $block) = @_;
         $self->values->sort_by($block);

--- a/scripts/Tests/arrays.sf
+++ b/scripts/Tests/arrays.sf
@@ -30,3 +30,27 @@ var r = [a.first_by { .is_odd }, a.last_by { .is_odd }]
 
 assert_eq(r.len, 2)
 assert_eq(r, [nil, nil])
+
+# Rest, last and first
+assert_eq(a.first(0), [])
+assert_eq(a.first, 4)
+assert_eq(a.first(2), [4, 8])
+assert_eq(a.first(4), a)
+assert_eq(a.first(5), a)
+
+assert_eq(a.last(0), [])
+assert_eq(a.last, 12)
+assert_eq(a.last(2), [10, 12])
+assert_eq(a.last(5), a)
+
+assert_eq(a.rest(-2), [8, 10, 12])
+assert_eq(a.rest, [8, 10, 12])
+assert_eq(a.rest(2), [10, 12])
+assert_eq(a.rest(3), [12])
+assert_eq(a.rest(4), [])
+assert_eq(a.rest(5), [8, 10, 12])
+assert_eq(a.rest(6), [8, 10, 12])
+
+assert_eq(a, [4, 8, 10, 12])
+
+say "** Test passed!"

--- a/scripts/Tests/set_first_rest.sf
+++ b/scripts/Tests/set_first_rest.sf
@@ -1,0 +1,31 @@
+#! /usr/bin/ruby
+
+const s = Set(1, 2, 3)
+const collector = []
+3.times{
+  var (f, r) = (s.first_rest)
+  assert_eq(2, r.len)
+  collector << (f, r...)
+  assert(f ~~ [1, 2, 3])
+  assert(f !~ r)
+}
+# Original set is unchanged
+assert_eq(s, Set(1, 2, 3))
+assert_eq(collector.flatten.sort, ([1] * 3) + ([2] * 3) + ([3] * 3))
+assert_eq(collector.sum, 9 * 2)
+
+var counter = 0
+const orig_set = Set( 0..10 -> ... )
+assert_eq( true, {
+  if (_) {
+    var (f, r) = .first_rest
+    counter += f
+    __BLOCK__(r)
+  } else { true }
+}(orig_set) )
+
+# Ensure original set was not changed
+assert_eq(orig_set, Set(0..10 -> ...))
+assert_eq(counter, 0..10 -> sum)
+
+say "** Test passed!"


### PR DESCRIPTION
Set.first_rest returns a list, of a 'random'
    element from a set, and a new set lacking
    that element.

Array.rest returns a new array lacking the first
    element from the original, or excluding the
    first `n` elements. If the argument is out of range, 

`Array.rest` is essentially just `arr.last(arr.len - 1)` but even for the default case it's better and less typing to have a builtin.