### PR TITLE
Fix Try.try, Block.ffork, and Fork.get having wrong values in some contexts

### DIFF
--- a/lib/Sidef/Types/Block/Block.pm
+++ b/lib/Sidef/Types/Block/Block.pm
@@ -410,8 +410,8 @@ package Sidef::Types::Block::Block {
 
         if ($pid == 0) {
             srand();
-            my $obj = $self->call(@args);
-            print $fh scalar Data::Dump::Filtered::dump_filtered($obj, \&__fdump);
+            my @objs = ( $self->call(@args) );
+            print $fh scalar Data::Dump::Filtered::dump_filtered(@objs, \&__fdump);
             exit 0;
         }
 

--- a/lib/Sidef/Types/Block/Fork.pm
+++ b/lib/Sidef/Types/Block/Fork.pm
@@ -27,9 +27,9 @@ package Sidef::Types::Block::Fork {
         };
 
         # Evaluate the result
-        my $result = eval($content);
+        my @result = ( eval($content) );
         $@ && die "[FORK ERROR] can't retrieve value: $@";
-        $result;
+        wantarray ? @result : @result[-1]
     }
 
     *wait = \&get;

--- a/lib/Sidef/Types/Block/Try.pm
+++ b/lib/Sidef/Types/Block/Try.pm
@@ -1,5 +1,6 @@
 package Sidef::Types::Block::Try {
 
+    use Data::Dumper;
     use utf8;
     use 5.016;
 
@@ -26,10 +27,13 @@ package Sidef::Types::Block::Try {
     sub catch {
         my ($self, $code) = @_;
 
-        $self->{catch}
-          ? $code->run(Sidef::Types::String::String->new($self->{type}),
-                       Sidef::Types::String::String->new($self->{msg} =~ s/^\[.*?\]\h*//r)->chomp)
-          : @{$self->{val}};
+        my @ret = ( $self->{catch}
+                    ? $code->run(Sidef::Types::String::String->new($self->{type}),
+                                 Sidef::Types::String::String->new($self->{msg} =~ s/^\[.*?\]\h*//r)->chomp)
+                    : @{$self->{val}}
+        );
+
+        wantarray ? @ret : @ret[-1]
     }
 
 };

--- a/scripts/Tests/try_catch.sf
+++ b/scripts/Tests/try_catch.sf
@@ -34,4 +34,23 @@ do {
     assert_eq(v, [true, "a", "b", "try_branch"])
 }
 
+const x = try {
+    (0, 1, 2)
+} catch {
+    (3, 4, 5)
+}
+
+assert_eq(Sys.ref(x), 'Sidef::Types::Number::Number')
+assert_eq(x, 2)
+
+const y = try {
+    die ()
+    (0, 1, 2)
+} catch {
+    (3, 4, 5)
+}
+
+assert_eq(Sys.ref(y), 'Sidef::Types::Number::Number')
+assert_eq(y, 5)
+
 say "** Test passed!"


### PR DESCRIPTION
`const x = try { (0, 1, 2) }...` was broken specifically because of `const` / `my state`, which doesn't treat list context the same way as `var` / `my`. This commit fixes it to return the last value in scalar context, instead of the unblessed scalar length of the list -- that's why the test asserts the ref is not `undef` / empty string.

Here's the omitted test for `.ffork`/`.wait` (which was broken), but I didn't add it as a file since I think it's dependent on `forks` being installed, and I didn't bother to add a check if it is installed. 

```ruby
var f = { (5, 6) }.ffork
var g = { 6 }.ffork

var a1 = [f.wait]
var a2 = [g.wait]

assert_eq(a1, [5, 6])
assert_eq(a2, [6])
```